### PR TITLE
Beacon major id was not ended correctly.

### DIFF
--- a/app/src/main/java/com/gelo/gelobeaconsampleapp/app/BeaconScanner.java
+++ b/app/src/main/java/com/gelo/gelobeaconsampleapp/app/BeaconScanner.java
@@ -79,8 +79,8 @@ public class BeaconScanner {
 
             if (UUIDHex.equals(GELO_UUID)) {
                 //Bytes 25 and 26 of the advertisement packet represent the major value
-                int major = (scanRecord[25] << 8)
-                        | (scanRecord[26] << 0);
+                int major = ((scanRecord[25]  & 0xFF) << 8)
+                        | (scanRecord[26]  & 0xFF);
 
                 //Bytes 27 and 28 of the advertisement packet represent the minor value
                 int minor = ((scanRecord[27] & 0xFF) << 8)


### PR DESCRIPTION
I couldn't find a good doc for the advertisement packet from Gelo. But majorId was coming back from the scan wrong every time. Finally, I realized the appending of the adding the null to the end of the bits in the majorid was not happening like it was for minorId.
